### PR TITLE
patched shares controller and comments controller

### DIFF
--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -64,11 +64,11 @@ class SharesController < ApplicationController
   end
 
   def set_share
-    @share = Share.find(params[:id])
+    @share = Share.find_by_id(params[:id])
   end
 
   def require_creator
-    access_denied unless user_signed_in? and (current_user == @share.user)
+    access_denied unless user_signed_in? && (current_user == @share.user)
   end
 
 end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CommentsController, type: :controller do
       user = FactoryGirl.create(:user)
       sign_in user
       get :edit, id: comment.id, share_id: comment.share.id
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to redirect_to root_path
     end
 
     it "should not let unauthenticated users edit a comment" do
@@ -61,7 +61,7 @@ RSpec.describe CommentsController, type: :controller do
       user = FactoryGirl.create(:user)
       sign_in user
       patch :update, id: comment.id, share_id: comment.share.id, comment: {body: "Updated"}
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to redirect_to root_path
     end
 
     it "should not let unauthenticated users edit a comment" do


### PR DESCRIPTION
Changed to use better syntax. Does render_not_found(:forbidden) just put up a 404? We should have more formalized error handling. Like a specific message, you do not have access to this feature and redirect back to the previous page or to the root_path.